### PR TITLE
changed timestamp of virtual files to mount-time

### DIFF
--- a/fuse-ts.c
+++ b/fuse-ts.c
@@ -742,6 +742,7 @@ int main (int argc, char *argv[]) {
 	int argc_new = argc;
 	char **argv_new = argv;
 	parse_opts (&argc_new, &argv_new);
+	time(&crtime);
 	sourcefiles = init_sourcefiles ();
 //	sourcefiles = cut_and_merge (sourcefiles, 0, lastframe, NULL, NULL, &sourcefiles_c);
 	update_cutmarks_from_numbers ();


### PR DESCRIPTION
This patch will set the timestamp of the virtual files to the time when the filesystem was mounted
