### PR TITLE
Fix for recent versions of shotcut

### DIFF
--- a/fuse-ts-shotcut.c
+++ b/fuse-ts-shotcut.c
@@ -225,15 +225,14 @@ int find_cutmarks_in_shotcut_project_file (int *inframe, int *outframe, int *bla
 
 static const char *sc_template =
 "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n"
-"<mlt LC_NUMERIC=\"de_DE.UTF-8\" version=\"0.9.2\" root=\"/tmp\" title=\"Anonymous Submission\" parent=\"producer0\" in=\"%1$d\" out=\"%6$d\">\n"
-"  <profile description=\"automatic\" width=\"720\" height=\"576\" progressive=\"1\" sample_aspect_num=\"16\" sample_aspect_den=\"15\" display_aspect_num=\"768\" display_aspect_den=\"576\" frame_rate_num=\"25\" frame_rate_den=\"1\" colorspace=\"601\"/>\n"
+"<mlt LC_NUMERIC=\"de_DE.UTF-8\" version=\"0.9.2\" title=\"Anonymous Submission\" parent=\"producer0\" in=\"%1$d\" out=\"%6$d\">\n"
+"  <profile description=\"automatic\" frame_rate_num=\"25\" frame_rate_den=\"1\" />\n"
 "  <producer id=\"producer0\" title=\"Anonymous Submission\" in=\"%1$d\" out=\"%6$d\">\n"
 "    <property name=\"mlt_type\">mlt_producer</property>\n"
 "    <property name=\"length\">%2$d</property>\n"
 "    <property name=\"eof\">pause</property>\n"
-"    <property name=\"resource\">%5$s</property>\n"
+"    <property name=\"resource\">uncut.ts</property>\n"
 "    <property name=\"seekable\">1</property>\n"
-"    <property name=\"aspect_ratio\">1,06667</property>\n"
 "    <property name=\"audio_index\">1</property>\n"
 "    <property name=\"video_index\">0</property>\n"
 "    <property name=\"mlt_service\">avformat</property>\n"

--- a/fuse-ts-shotcut.c
+++ b/fuse-ts-shotcut.c
@@ -225,14 +225,15 @@ int find_cutmarks_in_shotcut_project_file (int *inframe, int *outframe, int *bla
 
 static const char *sc_template =
 "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n"
-"<mlt LC_NUMERIC=\"de_DE.UTF-8\" version=\"0.9.2\" title=\"Anonymous Submission\" parent=\"producer0\" in=\"%1$d\" out=\"%6$d\">\n"
-"  <profile description=\"automatic\" frame_rate_num=\"25\" frame_rate_den=\"1\" />\n"
+"<mlt LC_NUMERIC=\"de_DE.UTF-8\" version=\"0.9.2\" root=\"/tmp\" title=\"Anonymous Submission\" parent=\"producer0\" in=\"%1$d\" out=\"%6$d\">\n"
+"  <profile description=\"automatic\" width=\"720\" height=\"576\" progressive=\"1\" sample_aspect_num=\"16\" sample_aspect_den=\"15\" display_aspect_num=\"768\" display_aspect_den=\"576\" frame_rate_num=\"25\" frame_rate_den=\"1\" colorspace=\"601\"/>\n"
 "  <producer id=\"producer0\" title=\"Anonymous Submission\" in=\"%1$d\" out=\"%6$d\">\n"
 "    <property name=\"mlt_type\">mlt_producer</property>\n"
 "    <property name=\"length\">%2$d</property>\n"
 "    <property name=\"eof\">pause</property>\n"
-"    <property name=\"resource\">uncut.ts</property>\n"
+"    <property name=\"resource\">%5$s</property>\n"
 "    <property name=\"seekable\">1</property>\n"
+"    <property name=\"aspect_ratio\">1,06667</property>\n"
 "    <property name=\"audio_index\">1</property>\n"
 "    <property name=\"video_index\">0</property>\n"
 "    <property name=\"mlt_service\">avformat</property>\n"

--- a/fuse-ts.c
+++ b/fuse-ts.c
@@ -249,7 +249,7 @@ static int ts_truncate (const char *path, off_t size) {
 		return 0;
 	case INDEX_SHOTCUT:
 	case INDEX_SHOTCUT_WIN:
-		truncate_shotcut_project_file();
+		if (size == 0 ) truncate_shotcut_project_file();
 		return 0;
 	case INDEX_INFRAME:
 		inframe_str_length = 0;


### PR DESCRIPTION
Current versions of shotcut trz to truncate the projectfile after writing to it to the final length. The shotcut_truncate handler function of fuse-ts will however always truncate the project to length 0. 
So this fix is calling shotcut_truncate only when a truncate with length 0 is requested.
