### PR TITLE
Update to current version of kdenlive

### DIFF
--- a/fuse-ts-knowledge.c
+++ b/fuse-ts-knowledge.c
@@ -36,6 +36,8 @@ int get_index_from_pathname(const char* path) {
 		return INDEX_DURATION;
 	} else if (strcmp (path, kdenlive_path) == 0) {
 		return INDEX_KDENLIVE;
+	} else if (path == strstr(path, "/project.kdenlive.") && kdenlive_tmp_path) {
+		return INDEX_KDENLIVE_TMP;
 	} else if (strcmp (path, shotcut_path) == 0) {
 		return INDEX_SHOTCUT;
 	} else if (path == strstr(path, "/shotcut-") && shotcut_tmp_path) {

--- a/fuse-ts-knowledge.h
+++ b/fuse-ts-knowledge.h
@@ -20,6 +20,7 @@ extern int get_index_from_pathname(const char* path);
 #define 	INDEX_FILELIST		14	// Index for '/filelist'
 #define 	INDEX_LOG		15	// Index for '/log'
 #define 	INDEX_SHOTCUT_TMP	16	// Index for '/shotcut-?????.mlt'
+#define 	INDEX_KDENLIVE_TMP	17	// Index for '/project.kdenlive.?????'
 
 
 #endif

--- a/fuse-ts.h
+++ b/fuse-ts.h
@@ -22,6 +22,7 @@ static const int read_block_size = 65536;
 extern FILE* logging;
 extern filebuffer_t* log_filebuffer;
 extern char * shotcut_tmp_path;
+extern char * kdenlive_tmp_path;
 
 extern char * base_dir ;
 extern char * start_time;


### PR DESCRIPTION
* Copy concept from shotcut fix
* Implemented new kdenlive project file format
* Implemented filesystem rename stub (as no-op for kdenlive case)
* Tested with kdenlive versions 21.04.3 and 22.04.3