### PR TITLE
Support for Shotcut 22

### DIFF
--- a/fuse-ts-knowledge.c
+++ b/fuse-ts-knowledge.c
@@ -40,7 +40,10 @@ int get_index_from_pathname(const char* path) {
 		return INDEX_KDENLIVE_TMP;
 	} else if (strcmp (path, shotcut_path) == 0) {
 		return INDEX_SHOTCUT;
-	} else if (path == strstr(path, "/shotcut-") && shotcut_tmp_path) {
+	} else if (shotcut_tmp_path && (
+		(strncmp (path, "/shotcut-", 9) == 0) ||
+		(strncmp (path, "/project_shotcut.mlt.", 21) == 0)
+	)) {
 		return INDEX_SHOTCUT_TMP;
 	} else if (strcmp (path, "/rebuild") == 0) {
 		return INDEX_REBUILD;

--- a/fuse-ts-shotcut.c
+++ b/fuse-ts-shotcut.c
@@ -216,7 +216,7 @@ int find_cutmarks_in_shotcut_project_file (int *inframe, int *outframe, int *bla
 
 static const char *sc_template =
 "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n"
-"<mlt LC_NUMERIC=\"C\" version=\"0.9.9\" title=\"FUSE-TS\" parent=\"producer0\" in=\"%1$d\" out=\"%6$d\">\n"
+"<mlt LC_NUMERIC=\"C\" version=\"6.25.0\" title=\"FUSE-TS\" parent=\"producer0\" in=\"%1$d\" out=\"%6$d\">\n"
 "  <profile description=\"automatic\" frame_rate_num=\"%8$d\" frame_rate_den=\"1\"/>\n"
 "  <producer id=\"producer0\" title=\"Source Clip\" in=\"%1$d\" out=\"%6$d\">\n"
 "    <property name=\"mlt_type\">mlt_producer</property>\n"

--- a/fuse-ts-shotcut.c
+++ b/fuse-ts-shotcut.c
@@ -36,7 +36,7 @@ filebuffer_t* get_shotcut_project_file_cache (const char *filename, int num_fram
 	if (sc_project_file_cache == NULL) sc_project_file_cache = filebuffer__new();
 	char* temp = (char *) malloc (size);
 	CHECK_OOM(temp);
-	int len = snprintf (temp, size - 1, sc_template, inframe, num_frames, num_frames - 1, outbyte, filename, _outframe, blanklen);
+	int len = snprintf (temp, size - 1, sc_template, inframe, num_frames, num_frames - 1, outbyte, filename, _outframe, blanklen, frames_per_second);
 	if (len >= size) err(124, "%s: size fail when generating project file\n", __FUNCTION__);
 	debug_printf ("get_shotcut_project_file: result has a size of: %d\n", len);
 	filebuffer__write(sc_project_file_cache, temp, len, 0);
@@ -212,12 +212,12 @@ int find_cutmarks_in_shotcut_project_file (int *inframe, int *outframe, int *bla
 
 //   %1$d => inframe,  %2$d => frames, %3$d => frames - 1 
 //   %4$(PRI64d) => filesize, %5$s => filename without path
-//   %6$d => outframe
+//   %6$d => outframe, %8$d => fps
 
 static const char *sc_template =
 "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n"
 "<mlt LC_NUMERIC=\"C\" version=\"0.9.9\" title=\"FUSE-TS\" parent=\"producer0\" in=\"%1$d\" out=\"%6$d\">\n"
-"  <profile description=\"automatic\" />\n"
+"  <profile description=\"automatic\" frame_rate_num=\"%8$d\" frame_rate_den=\"1\"/>\n"
 "  <producer id=\"producer0\" title=\"Source Clip\" in=\"%1$d\" out=\"%6$d\">\n"
 "    <property name=\"mlt_type\">mlt_producer</property>\n"
 "    <property name=\"length\">%2$d</property>\n"
@@ -235,7 +235,7 @@ static const char *sc_template =
 "  <!--\n"
 "  %1$d => inframe,  %2$d => frames, %3$d => frames - 1\n"
 "  %4$" PRId64 " => filesize, %5$s => filename without path\n"
-"  %6$d => outframe %7$d => blanklen\n"
+"  %6$d => outframe %7$d => blanklen %8$d => fps\n"
 "  -->\n"
 "</mlt>\n";
 

--- a/fuse-ts-shotcut.c
+++ b/fuse-ts-shotcut.c
@@ -126,12 +126,7 @@ int find_cutmarks_in_shotcut_project_file (int *inframe, int *outframe, int *bla
 		debug_printf ("find_cutmarks: file has not been written to.\n");
 		return 100;
 	}
-/*
-  in XPATH, I would look for 
-    producer[@id='producer0']/@in
-  and
-    producer[@id='producer0']/@out
-*/
+
 	mxml_node_t *xmldoc;
 	char* temp = filebuffer__read_all_to_cstring(sc_writebuffer);
 	xmldoc = mxmlLoadString (NULL, temp, MXML_TEXT_CALLBACK);
@@ -140,12 +135,16 @@ int find_cutmarks_in_shotcut_project_file (int *inframe, int *outframe, int *bla
 		debug_printf ("find_cutmarks: no valid XML!\n");
 		return 1;
 	}
+
 	mxml_node_t *node;
 	node = mxmlFindElement (xmldoc, xmldoc, "producer", "id", "producer0", MXML_DESCEND);
 	if (NULL == node) {
-		debug_printf ("find_cutmarks: node with id 'producer0' not found!\n");
-		mxmlRelease (xmldoc);
-		return 2;
+		node = mxmlFindElement (xmldoc, xmldoc, "chain", "id", "chain0", MXML_DESCEND);
+		if (NULL == node) {
+			debug_printf ("find_cutmarks: node with id 'producer0' or 'chain0' not found!\n");
+			mxmlRelease (xmldoc);
+			return 2;
+		}
 	}
 
 	int blank = 0;

--- a/fuse-ts.c
+++ b/fuse-ts.c
@@ -105,8 +105,8 @@ static int ts_getattr (const char *path, struct stat *stbuf) {
 		return -ENOENT;
 	if (entrynr == INDEX_KDENLIVE_TMP && kdenlive_tmp_path == NULL)
 		return -ENOENT;
-	if (entrynr == INDEX_SHOTCUT_TMP && shotcut_tmp_path == NULL)
-		return -ENOENT;
+	//if (entrynr == INDEX_SHOTCUT_TMP && shotcut_tmp_path == NULL)
+	//	return -ENOENT;
 
 	stbuf->st_ino = (pid_nr << 16) | entrynr;
 	stbuf->st_mode = S_IFREG | 0444;
@@ -152,7 +152,7 @@ static int ts_getattr (const char *path, struct stat *stbuf) {
 		stbuf->st_size = get_kdenlive_project_file_size (rawName + 1, totalframes, blanklen);
 		break;
 	case INDEX_SHOTCUT:
-	case INDEX_SHOTCUT_TMP:
+	//case INDEX_SHOTCUT_TMP:
 		stbuf->st_mode = S_IFREG | 0666;
 		stbuf->st_size = 0;
 		stbuf->st_size = get_shotcut_project_file_size (rawName + 1, totalframes, blanklen);
@@ -210,7 +210,9 @@ static int ts_readdir (const char *path, void *buf, fuse_fill_dir_t filler, off_
 
 static int ts_create (const char* path, mode_t mode, struct fuse_file_info *fi) {
 	debug_printf ("create called on '%s'\n", path);
-
+	if (strncmp (path, "/shotcut-", 9) == 0) {
+		return -EACCES;
+/*
 	if (strncmp (path, "/shotcut-", 9) == 0) {
 		fi->fh = 0;
 		if (shotcut_tmp_path) free(shotcut_tmp_path);
@@ -218,6 +220,7 @@ static int ts_create (const char* path, mode_t mode, struct fuse_file_info *fi) 
 		open_shotcut_project_file (rawName + 1, totalframes, blanklen, 1);
 		return 0;
 	}
+*/
 	if (strncmp (path, "/project.kdenlive.", 18) == 0) {
 		fi->fh = 0;
 		if (kdenlive_tmp_path) free(kdenlive_tmp_path);
@@ -257,11 +260,13 @@ static int ts_open (const char *path, struct fuse_file_info *fi) {
 		open_kdenlive_project_file (rawName + 1, totalframes, blanklen, ((fi->flags & O_TRUNC) > 0));
 		return 0;
 	case INDEX_SHOTCUT:
-	case INDEX_SHOTCUT_TMP:
+	//case INDEX_SHOTCUT_TMP:
 		if (totalframes < 0)
 			return -ENOENT;
 		open_shotcut_project_file (rawName + 1, totalframes, blanklen, ((fi->flags & O_TRUNC) > 0));
 		return 0;
+	case INDEX_SHOTCUT_TMP:
+		return -EACCES;
 	case INDEX_PID:
 	case INDEX_INTIME:
 	case INDEX_OUTTIME:
@@ -290,7 +295,7 @@ static int ts_truncate (const char *path, off_t size) {
 	case INDEX_KDENLIVE_TMP:
 		return truncate_kdenlive_project_file(size);
 	case INDEX_SHOTCUT:
-	case INDEX_SHOTCUT_TMP:
+	//case INDEX_SHOTCUT_TMP:
 		return truncate_shotcut_project_file(size);
 	case INDEX_INFRAME:
 		tmp = truncate_buffer(&inframe_str, inframe_str_length, size);
@@ -460,10 +465,11 @@ static int ts_read (const char *path, char *buf, size_t size, off_t offset, stru
 			return -ENOENT;
 		return kdenlive_read (path, buf, size, offset, rawName, totalframes, blanklen);
 	case INDEX_SHOTCUT:
-	case INDEX_SHOTCUT_TMP:
 		if (totalframes < 0)
 			return -ENOENT;
 		return shotcut_read (path, buf, size, offset, rawName, totalframes, blanklen);
+	case INDEX_SHOTCUT_TMP:
+		return -EACCES;
 	}
 	error_printf ("Path not found: '%s' \n", path);
 	return -ENOENT;
@@ -477,7 +483,7 @@ int ts_write (const char *path, const char *buf, size_t size, off_t offset, stru
 	case INDEX_KDENLIVE_TMP:
 		return write_kdenlive_project_file (buf, size, offset);
 	case INDEX_SHOTCUT:
-	case INDEX_SHOTCUT_TMP:
+	//case INDEX_SHOTCUT_TMP:
 		return write_shotcut_project_file (buf, size, offset);
 	case INDEX_INFRAME:
 		return write_to_buffer (buf, size, offset, &inframe_str, &inframe_str_length);
@@ -513,7 +519,7 @@ int ts_release (const char *filename, struct fuse_file_info *info) {
 		close_kdenlive_project_file ();
 		break;
 	case INDEX_SHOTCUT:
-	case INDEX_SHOTCUT_TMP:
+	//case INDEX_SHOTCUT_TMP:
 		if (totalframes < 0)
 			return -ENOENT;
 		if (find_cutmarks_in_shotcut_project_file (&inframe, &outframe, &blanklen) == 0) {

--- a/fuse-ts.c
+++ b/fuse-ts.c
@@ -105,8 +105,6 @@ static int ts_getattr (const char *path, struct stat *stbuf) {
 		return -ENOENT;
 	if (entrynr == INDEX_KDENLIVE_TMP && kdenlive_tmp_path == NULL)
 		return -ENOENT;
-	//if (entrynr == INDEX_SHOTCUT_TMP && shotcut_tmp_path == NULL)
-	//	return -ENOENT;
 
 	stbuf->st_ino = (pid_nr << 16) | entrynr;
 	stbuf->st_mode = S_IFREG | 0444;
@@ -152,7 +150,6 @@ static int ts_getattr (const char *path, struct stat *stbuf) {
 		stbuf->st_size = get_kdenlive_project_file_size (rawName + 1, totalframes, blanklen);
 		break;
 	case INDEX_SHOTCUT:
-	//case INDEX_SHOTCUT_TMP:
 		stbuf->st_mode = S_IFREG | 0666;
 		stbuf->st_size = 0;
 		stbuf->st_size = get_shotcut_project_file_size (rawName + 1, totalframes, blanklen);
@@ -214,15 +211,6 @@ static int ts_create (const char* path, mode_t mode, struct fuse_file_info *fi) 
 		(strncmp (path, "/shotcut-", 9) == 0) ||
 		(strncmp (path, "/project_shotcut.mlt.", 21) == 0)
 	) return -EACCES;
-/*
-	if (strncmp (path, "/shotcut-", 9) == 0) {
-		fi->fh = 0;
-		if (shotcut_tmp_path) free(shotcut_tmp_path);
-		shotcut_tmp_path = dupe_str(path);
-		open_shotcut_project_file (rawName + 1, totalframes, blanklen, 1);
-		return 0;
-	}
-*/
 	if (strncmp (path, "/project.kdenlive.", 18) == 0) {
 		fi->fh = 0;
 		if (kdenlive_tmp_path) free(kdenlive_tmp_path);
@@ -262,7 +250,6 @@ static int ts_open (const char *path, struct fuse_file_info *fi) {
 		open_kdenlive_project_file (rawName + 1, totalframes, blanklen, ((fi->flags & O_TRUNC) > 0));
 		return 0;
 	case INDEX_SHOTCUT:
-	//case INDEX_SHOTCUT_TMP:
 		if (totalframes < 0)
 			return -ENOENT;
 		open_shotcut_project_file (rawName + 1, totalframes, blanklen, ((fi->flags & O_TRUNC) > 0));
@@ -297,7 +284,6 @@ static int ts_truncate (const char *path, off_t size) {
 	case INDEX_KDENLIVE_TMP:
 		return truncate_kdenlive_project_file(size);
 	case INDEX_SHOTCUT:
-	//case INDEX_SHOTCUT_TMP:
 		return truncate_shotcut_project_file(size);
 	case INDEX_INFRAME:
 		tmp = truncate_buffer(&inframe_str, inframe_str_length, size);
@@ -485,7 +471,6 @@ int ts_write (const char *path, const char *buf, size_t size, off_t offset, stru
 	case INDEX_KDENLIVE_TMP:
 		return write_kdenlive_project_file (buf, size, offset);
 	case INDEX_SHOTCUT:
-	//case INDEX_SHOTCUT_TMP:
 		return write_shotcut_project_file (buf, size, offset);
 	case INDEX_INFRAME:
 		return write_to_buffer (buf, size, offset, &inframe_str, &inframe_str_length);
@@ -521,7 +506,6 @@ int ts_release (const char *filename, struct fuse_file_info *info) {
 		close_kdenlive_project_file ();
 		break;
 	case INDEX_SHOTCUT:
-	//case INDEX_SHOTCUT_TMP:
 		if (totalframes < 0)
 			return -ENOENT;
 		if (find_cutmarks_in_shotcut_project_file (&inframe, &outframe, &blanklen) == 0) {

--- a/fuse-ts.c
+++ b/fuse-ts.c
@@ -210,8 +210,10 @@ static int ts_readdir (const char *path, void *buf, fuse_fill_dir_t filler, off_
 
 static int ts_create (const char* path, mode_t mode, struct fuse_file_info *fi) {
 	debug_printf ("create called on '%s'\n", path);
-	if (strncmp (path, "/shotcut-", 9) == 0) {
-		return -EACCES;
+	if (
+		(strncmp (path, "/shotcut-", 9) == 0) ||
+		(strncmp (path, "/project_shotcut.mlt.", 21) == 0)
+	) return -EACCES;
 /*
 	if (strncmp (path, "/shotcut-", 9) == 0) {
 		fi->fh = 0;


### PR DESCRIPTION
This PR improves Support for Shotcut 22 by implementing the new ML-XML Format which uses `<chain>` instead of `<producer>`. Also Write-Access to the Tempfiles is rejected for both the Shotcut 19+ as well as the Shotcut 22 Tempfile Naming-Schema in order to prevent QtSaveFile from performing an atomic write, which fuse-ts does not support.

Fixes #13
