### PR TITLE
Makefile: add EXTRA_LFLAGS to linker command line

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 DEBUGopts = -g -O0 -fno-inline-functions -DDEBUG
 NDEBUGopts = $(EXTRA_CFLAGS) -O2 -DNDEBUG
 CFLAGS = -Wall -c $(DEBUG) -D_FILE_OFFSET_BITS=64 -DFUSE_USE_VERSION=25
-LFLAGS = -Wall -lmxml -lfuse $(DEBUG)
+LFLAGS = -Wall -lmxml -lfuse $(DEBUG) $(EXTRA_LFLAGS)
 CC = gcc
 DEBUG=$(NDEBUGopts)
 


### PR DESCRIPTION
This allows custom linker flags to be set by users/packagers (e.g. to switch the linker used for linking the software).

See-Also: https://gitlab.fem-net.de/gentoo/fem-overlay/-/issues/66