### PR TITLE
fix compiler warnings and add some mutexes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 DEBUGopts = -g -O0 -fno-inline-functions -DDEBUG
 NDEBUGopts = $(EXTRA_CFLAGS) -O2 -DNDEBUG
-CFLAGS = -Wall -c $(DEBUG) -D_FILE_OFFSET_BITS=64 -DFUSE_USE_VERSION=25
-LFLAGS = -Wall -lmxml -lfuse $(DEBUG) $(EXTRA_LFLAGS)
+CFLAGS = -Wall -g -Wpedantic -c $(DEBUG) -D_FILE_OFFSET_BITS=64 -DFUSE_USE_VERSION=25
+LFLAGS = -Wall -g -Wpedantic -lmxml -lfuse $(DEBUG) $(EXTRA_LFLAGS)
 CC = gcc
 DEBUG=$(NDEBUGopts)
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+fuse-ts (2024.07.26.1) stable; urgency=low
+
+  * build: be pedantic
+  * bugfix: fixed issues with multi threaded file access
+
+ -- Lukas Schauer <lukas2511@c3voc.de>  Fri, 26 Jul 2024 01:17:00 +0200
+
 fuse-ts (2023.09.18.1) stable; urgency=low
 
   * build: add $(EXTRA_LFLAGS) to Makefile

--- a/fuse-ts-debug.h
+++ b/fuse-ts-debug.h
@@ -1,6 +1,6 @@
 #ifdef DEBUG
 extern void debug_printf(const char * text, ...);
-#define DEPRECATED(...) debug_printf("XXX use of DEPRECATED function %s\n", __FUNCTION__);
+#define DEPRECATED(...) debug_printf("XXX use of DEPRECATED function %s\n", __func__);
 #else
 #define debug_printf(...)
 #define DEPRECATED(...)

--- a/fuse-ts-filebuffer.c
+++ b/fuse-ts-filebuffer.c
@@ -147,7 +147,7 @@ size_t filebuffer__contentsize (filebuffer_t* self) {
 }
 
 char* filebuffer__read_all_to_cstring (filebuffer_t* self) {
-	debug_printf("%s on %p\n", __FUNCTION__, self);
+	debug_printf("%s on %p\n", __func__, self);
 	if (self == NULL) {
 		error_printf ("reading complete buffer failed: NULL pointer!\n");
 		return NULL;

--- a/fuse-ts-filelist.c
+++ b/fuse-ts-filelist.c
@@ -356,7 +356,7 @@ sourcefile_t *get_sourcefile_for_position (sourcefile_t * list, off_t pos) {
 
 off_t get_filesize (char *name) {
 	struct stat st;
-	memset (&st, 0, sizeof (stat));
+	memset (&st, 0, sizeof(struct stat));
 	stat (name, &st);
 	off_t size = st.st_size;
 	return size;

--- a/fuse-ts-kdenlive.c
+++ b/fuse-ts-kdenlive.c
@@ -27,7 +27,7 @@ static filebuffer_t* kl_writebuffer = NULL;
 filebuffer_t* get_kdenlive_project_file_cache (const char *filename, int num_frames, int blanklen) {
 	pthread_mutex_lock (&kl_cachemutex);
 	if ((kl_project_file_cache != NULL) && (kl_project_file_cache_inframe == inframe) && (kl_project_file_cache_outframe == outframe) && (kl_project_file_cache_blanklen == blanklen)) {
-		debug_printf ("%s: cache hit (%p)\n", __FUNCTION__, kl_project_file_cache);
+		debug_printf ("%s: cache hit (%p)\n", __func__, kl_project_file_cache);
 		pthread_mutex_unlock (&kl_cachemutex);
 		return kl_project_file_cache;
 	}
@@ -40,8 +40,8 @@ filebuffer_t* get_kdenlive_project_file_cache (const char *filename, int num_fra
 	char* temp = (char *) malloc (size);
 	CHECK_OOM(temp);
 	int len = snprintf (temp, size - 1, kl_template, _inframe, num_frames, num_frames - 1, outbyte, t, _outframe, blanklen, frames_per_second, width, height);
-	if (len >= size) err(124, "%s: size fail when generating project file\n", __FUNCTION__);
-	debug_printf ("%s: result has a size of: %d\n", __FUNCTION__, len);
+	if (len >= size) err(124, "%s: size fail when generating project file\n", __func__);
+	debug_printf ("%s: result has a size of: %d\n", __func__, len);
 	filebuffer__write(kl_project_file_cache, temp, len, 0);
 	filebuffer__truncate(kl_project_file_cache, len);
 	kl_project_file_cache_inframe = inframe;
@@ -56,14 +56,14 @@ filebuffer_t* get_kdenlive_project_file_cache (const char *filename, int num_fra
 size_t get_kdenlive_project_file_size (const char *filename, int num_frames, int blanklen) {
 	filebuffer_t* fb = get_kdenlive_project_file_cache (filename, num_frames, blanklen);
 	if (fb == NULL) return -EIO;
-	debug_printf ("%s: result is: %d\n", __FUNCTION__, filebuffer__contentsize(fb));
+	debug_printf ("%s: result is: %d\n", __func__, filebuffer__contentsize(fb));
 	return filebuffer__contentsize(fb);
 }
 
 void init_kdenlive_project_file () {
 	pthread_mutex_lock (&kl_cachemutex);
 	if (kl_project_file_cache != NULL) {
-		debug_printf ("%s: freeing cache %p\n", __FUNCTION__, kl_project_file_cache);
+		debug_printf ("%s: freeing cache %p\n", __func__, kl_project_file_cache);
 		filebuffer__destroy (kl_project_file_cache);
 		kl_project_file_cache = NULL;
 	}
@@ -78,7 +78,7 @@ size_t kdenlive_read (const char *path, char *buf, size_t size, off_t offset, co
 }
 
 void open_kdenlive_project_file (const char *movie_path, int frames, int blanklen, int truncate) {
-	debug_printf ("%s\n", __FUNCTION__);
+	debug_printf ("%s\n", __func__);
 	kl_project_file_refcount++;
 	if (kl_project_file_refcount > 1) return;
 	if (kl_writebuffer == NULL) {

--- a/fuse-ts-shotcut.c
+++ b/fuse-ts-shotcut.c
@@ -37,7 +37,7 @@ filebuffer_t* get_shotcut_project_file_cache (const char *filename, int num_fram
 	char* temp = (char *) malloc (size);
 	CHECK_OOM(temp);
 	int len = snprintf (temp, size - 1, sc_template, inframe, num_frames, num_frames - 1, outbyte, filename, _outframe, blanklen, frames_per_second);
-	if (len >= size) err(124, "%s: size fail when generating project file\n", __FUNCTION__);
+	if (len >= size) err(124, "%s: size fail when generating project file\n", __func__);
 	debug_printf ("get_shotcut_project_file: result has a size of: %d\n", len);
 	filebuffer__write(sc_project_file_cache, temp, len, 0);
 	filebuffer__truncate(sc_project_file_cache, len);

--- a/fuse-ts-tools.h
+++ b/fuse-ts-tools.h
@@ -33,4 +33,4 @@ extern int file_exists (const char * filename);
 ///////////////// memory stuff  ///////////////
 
 #include <err.h>
-#define CHECK_OOM(pointer) if (pointer == NULL) err (123, "Out of memory! (function: %s) Exiting!\n", __FUNCTION__);
+#define CHECK_OOM(pointer) if (pointer == NULL) err (123, "Out of memory! (function: %s) Exiting!\n", __func__);

--- a/fuse-ts.h
+++ b/fuse-ts.h
@@ -61,6 +61,7 @@ typedef struct _sourcefile {
   int refcnt;
   off_t filesize; // size of this piece in bytes
   off_t totalsize; // cumulation of bytes including this piece
+  pthread_mutex_t filelock;
 } sourcefile_t;
 
 typedef struct _fileposhint {


### PR DESCRIPTION
added some mutexes because fuse-ts sometimes served data from wrong positions in the source files. after adding the mutexes this behaviour couldn't be observed anymore.

since my compiler was quite new it threw a lot of ugly warnings around, so i also made some changes to get rid of them