### PR TITLE
Update to new kdenlive version

### DIFF
--- a/fuse-ts-kdenlive.c
+++ b/fuse-ts-kdenlive.c
@@ -2,6 +2,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <inttypes.h>
+#include <stdbool.h>
 #include <fcntl.h>
 #include <sys/types.h>
 #include <assert.h>
@@ -24,6 +25,25 @@ static pthread_mutex_t kl_cachemutex = PTHREAD_MUTEX_INITIALIZER;
 
 static filebuffer_t* kl_writebuffer = NULL;
 
+bool format_frame_count_to_timestring (char *output, size_t output_size, int frame_count) {
+	bool neg = false;
+	if (frame_count < 0) {
+		frame_count = -frame_count;
+		neg = true;
+	}
+	int hours = frame_count / (3600 * frames_per_second);
+	frame_count %= 3600 * frames_per_second;
+	int minutes = frame_count / (60 * frames_per_second);
+	frame_count %= 60 * frames_per_second;
+	float seconds = (float) frame_count / frames_per_second;
+	int len;
+	if (neg)
+		len = snprintf(output, output_size, "-%02d:%02d:%02.3f", hours, minutes, seconds);
+	else
+		len = snprintf(output, output_size, "%02d:%02d:%02.3f", hours, minutes, seconds);
+	return len < output_size;
+}
+
 filebuffer_t* get_kdenlive_project_file_cache (const char *filename, int num_frames, int blanklen) {
 	pthread_mutex_lock (&kl_cachemutex);
 	if ((kl_project_file_cache != NULL) && (kl_project_file_cache_inframe == inframe) && (kl_project_file_cache_outframe == outframe) && (kl_project_file_cache_blanklen == blanklen)) {
@@ -35,11 +55,39 @@ filebuffer_t* get_kdenlive_project_file_cache (const char *filename, int num_fra
 	int _inframe = inframe;
 	char *t = merge_strs (3, mountpoint, "/", filename);
 
+	char blanklen_timestr[20];
+	char intime_timestr[20];
+	char outtime_timestr[20];
+	char numframes_timestr[20];
+	char numframes_m1_timestr[20];
+	bool format_success = true;
+	format_success = format_success && format_frame_count_to_timestring(blanklen_timestr, sizeof(blanklen_timestr), blanklen);
+	format_success = format_success && format_frame_count_to_timestring(intime_timestr, sizeof(intime_timestr), _inframe);
+	format_success = format_success && format_frame_count_to_timestring(outtime_timestr, sizeof(outtime_timestr), _outframe);
+	format_success = format_success && format_frame_count_to_timestring(numframes_timestr, sizeof(numframes_timestr), num_frames);
+	format_success = format_success && format_frame_count_to_timestring(numframes_m1_timestr, sizeof(numframes_m1_timestr), num_frames-1);
+	if (!format_success) err(124, "%s: size fail when formatting time string\n", __func__);
+
 	const size_t size = strlen(kl_template) * 2;
 	if (kl_project_file_cache == NULL) kl_project_file_cache = filebuffer__new();
 	char* temp = (char *) malloc (size);
 	CHECK_OOM(temp);
-	int len = snprintf (temp, size - 1, kl_template, _inframe, num_frames, num_frames - 1, outbyte, t, _outframe, blanklen, frames_per_second, width, height);
+	int len = snprintf (temp, size - 1, kl_template,
+			_inframe,
+			num_frames,
+			num_frames - 1,
+			outbyte,
+			t,
+			_outframe,
+			blanklen,
+			frames_per_second,
+			width,
+			height,
+			blanklen_timestr,
+			intime_timestr,
+			outtime_timestr,
+			numframes_timestr,
+			numframes_m1_timestr);
 	if (len >= size) err(124, "%s: size fail when generating project file\n", __func__);
 	debug_printf ("%s: result has a size of: %d\n", __func__, len);
 	filebuffer__write(kl_project_file_cache, temp, len, 0);
@@ -153,9 +201,9 @@ int find_cutmarks_in_kdenlive_project_file (int *inframe, int *outframe, int *bl
 	}
 /*
   in XPATH, I would look for 
-    playlist[@id='playlist1']/entry[@producer='1']/@in
+    playlist[@id='playlist0']/entry[@producer='chain0']/@in
   and
-    playlist[@id='playlist1']/entry[@producer='1']/@out
+    playlist[@id='playlist0']/entry[@producer='chain0']/@out
 */
 	mxml_node_t *xmldoc;
 	char* temp = filebuffer__read_all_to_cstring(kl_writebuffer);
@@ -168,7 +216,7 @@ int find_cutmarks_in_kdenlive_project_file (int *inframe, int *outframe, int *bl
 	mxml_node_t *node, *subnode;
 	node = mxmlFindElement (xmldoc, xmldoc, "playlist", "id", "playlist0", MXML_DESCEND);
 	if (NULL == node) {
-		debug_printf ("find_cutmarks: node with id 'playlist1' not found!\n");
+		debug_printf ("find_cutmarks: node with id 'playlist0' not found!\n");
 		mxmlRelease (xmldoc);
 		return 2;
 	}
@@ -192,7 +240,7 @@ int find_cutmarks_in_kdenlive_project_file (int *inframe, int *outframe, int *bl
 		}
 	}
 
-	node = mxmlFindElement (node, node, "entry", "producer", "1", MXML_DESCEND);
+	node = mxmlFindElement (node, node, "entry", "producer", "chain0", MXML_DESCEND);
 	if (NULL == node) {
 		debug_printf ("find_cutmarks: node 'entry' in playlist not found!\n");
 		mxmlRelease (xmldoc);
@@ -239,10 +287,13 @@ int find_cutmarks_in_kdenlive_project_file (int *inframe, int *outframe, int *bl
 
 static const char *kl_template =
 "<?xml version='1.0' encoding='utf-8'?>"
-"<mlt title=\"Anonymous Submission\" root=\"/tmp\" version=\"0.8.8\">"
+"<mlt LC_NUMERIC=\"C\" producer=\"main_bin\" version=\"7.22.0\" root=\"/tmp\">"
 " <!-- %1$d => inframe,  %2$d => frames, %3$d => frames - 1  "
 "  %4$" PRId64 " => filesize, %5$s => filename with path "
-"  %6$d => outframe, %7$d => blanktime --> "
+"  %6$d => outframe, %7$d => blanklen, "
+"  %8$d => frames_per_second, %9$d => width, %10$d => height "
+"  %11$s => blanklen_time, %12$s => intime "
+"  %13$s => outtime, %14$s => total_time, %15$s => total_time - 1 frame --> "
 // Omitting aspect ratio crashes KDEnlive, so living with hardcoded values.
 // Cutting other formats should be possible anyway, KDEnlive will just scale
 // it wrong if it is not 16:9.
@@ -250,44 +301,106 @@ static const char *kl_template =
 " display_aspect_num=\"16\" display_aspect_den=\"9\" frame_rate_num=\"%8$d\" "
 " colorspace=\"709\" sample_aspect_den=\"1\" description=\"HD 1080i %8$d fps\" "
 " progressive=\"0\" sample_aspect_num=\"1\"/> "
-" <producer in=\"0\" out=\"%3$d\" id=\"black\">"
-"  <property name=\"mlt_type\">producer</property>"
-"  <property name=\"aspect_ratio\">0</property>"
-"  <property name=\"length\">%2$d</property>"
-"  <property name=\"eof\">pause</property>"
+" <producer id=\"producer0\" in=\"00:00:00.000\" out=\"%14$s\">"
+"  <property name=\"length\">2147483647</property>"  // maxint
+"  <property name=\"eof\">continue</property>"
 "  <property name=\"resource\">black</property>"
-"  <property name=\"mlt_service\">colour</property>"
+"  <property name=\"aspect_ratio\">1</property>"
+"  <property name=\"mlt_service\">color</property>"
+"  <property name=\"kdenlive:playlistid\">black_track</property>"
 " </producer>"
-" <playlist id=\"black_track\">"
-"  <entry in=\"0\" out=\"%3$d\" producer=\"black\"/>"
-" </playlist>"
-" <producer in=\"0\" out=\"%3$d\" id=\"1\">"
-"  <property name=\"mlt_type\">producer</property>"
+" <chain id=\"chain0\" out=\"%15$s\">"
 "  <property name=\"length\">%2$d</property>"
 "  <property name=\"eof\">pause</property>"
 "  <property name=\"resource\">%5$s</property>"
-"  <property name=\"mlt_service\">avformat</property>"
-"  <property name=\"source_fps\">%8$d.000000</property>"
-" </producer>"
-" <playlist id=\"playlist1\">"
-"  <blank length=\"%7$d\"/>"
-"  <entry in=\"%1$d\" out=\"%6$d\" producer=\"1\"/>"
+"  <property name=\"audio_index\">1</property>"
+"  <property name=\"video_index\">0</property>"
+"  <property name=\"kdenlive:id\">4</property>"
+"  <property name=\"mute_on_pause\">0</property>"
+" </chain>"
+" <playlist id=\"playlist0\">"
+"  <property name=\"kdenlive:audio_track\">1</property>"
+"  <blank length=\"%11$s\"/>"
+"  <entry producer=\"chain0\" in=\"%12$s\" out=\"%13$s\">"
+"   <property name=\"kdenlive:id\">4</property>"
+"  </entry>"
 " </playlist>"
-" <tractor title=\"Anonymous Submission\" global_feed=\"1\" in=\"0\" out=\"%3$d\" id=\"maintractor\">"
-"  <track producer=\"black_track\"/>"
-"  <track producer=\"playlist1\"/>"
+" <playlist id=\"playlist1\">"
+"  <property name=\"kdenlive:audio_track\">1</property>"
+" </playlist>"
+" <tractor id=\"tractor0\" in=\"00:00:00.000\" out=\"%15$s\">"
+"  <property name=\"kdenlive:audio_track\">1</property>"
+"  <property name=\"kdenlive:trackheight\">59</property>"
+"  <property name=\"kdenlive:timeline_active\">1</property>"
+"  <property name=\"kdenlive:collapsed\">0</property>"
+"  <track hide=\"video\" producer=\"playlist0\"/>"
+"  <track hide=\"video\" producer=\"playlist1\"/>"
 " </tractor>"
-" <kdenlivedoc kdenliveversion=\"0.9.10\" version=\"0.88\" projectfolder=\"/tmp/kdenlive\">"
-"  <documentproperties zonein=\"0\" zoneout=\"100\" zoom=\"10\" verticalzoom=\"1\" position=\"0\"/>"
-"  <tracksinfo>"
-"   <trackinfo blind=\"0\" mute=\"0\" locked=\"0\" trackname=\"Cut me\"/>"
-"  </tracksinfo>"
-"  <kdenlive_producer id=\"1\" default_video=\"0\" fps=\"%8$d.000000\" name=\"uncut.ts\" resource=\"%5$s\" duration=\"%2$d\" type=\"3\" />"
-"  <markers/>"
-"  <groups/>"
-" </kdenlivedoc>"
+" <chain id=\"chain1\" out=\"%15$s\">"
+"  <property name=\"length\">%2$d</property>"
+"  <property name=\"eof\">pause</property>"
+"  <property name=\"resource\">%5$s</property>"
+"  <property name=\"audio_index\">1</property>"
+"  <property name=\"video_index\">0</property>"
+"  <property name=\"kdenlive:id\">4</property>"
+"  <property name=\"mute_on_pause\">0</property>"
+" </chain>"
+" <playlist id=\"playlist2\">"
+"  <blank length=\"%11$s\"/>"
+"  <entry producer=\"chain1\" in=\"%12$s\" out=\"%13$s\">"
+"   <property name=\"kdenlive:id\">4</property>"
+"  </entry>"
+" </playlist>"
+" <playlist id=\"playlist3\"/>"
+" <tractor id=\"tractor1\" in=\"00:00:00.000\" out=\"%15$s\">"
+"  <property name=\"kdenlive:trackheight\">59</property>"
+"  <property name=\"kdenlive:timeline_active\">1</property>"
+"  <property name=\"kdenlive:collapsed\">0</property>"
+"  <property name=\"kdenlive:track_name\">Cut Me -&gt;</property>"
+"  <track hide=\"audio\" producer=\"playlist2\"/>"
+"  <track hide=\"audio\" producer=\"playlist3\"/>"
+" </tractor>"
+" <tractor id=\"maintractor\" in=\"00:00:00.000\" out=\"%14$s\">"
+"  <property name=\"kdenlive:uuid\">maintractor</property>"
+"  <property name=\"kdenlive:clipname\">Sequence 1</property>"
+"  <property name=\"kdenlive:sequenceproperties.hasAudio\">1</property>"
+"  <property name=\"kdenlive:sequenceproperties.hasVideo\">1</property>"
+"  <property name=\"kdenlive:sequenceproperties.activeTrack\">1</property>"
+"  <property name=\"kdenlive:sequenceproperties.tracksCount\">2</property>"
+"  <property name=\"kdenlive:sequenceproperties.documentuuid\">maintractor</property>"
+"  <property name=\"kdenlive:duration\">%14$s</property>"
+"  <property name=\"kdenlive:maxduration\">%2$d</property>"
+"  <property name=\"kdenlive:producer_type\">17</property>"
+"  <property name=\"kdenlive:id\">3</property>"
+"  <property name=\"kdenlive:clip_type\">0</property>"
+"  <property name=\"kdenlive:sequenceproperties.groups\">[ { \"children\": [ { \"data\": \"1:0\", \"leaf\": \"clip\", \"type\": \"Leaf\" }, { \"data\": \"0:0\", \"leaf\": \"clip\", \"type\": \"Leaf\" } ], \"type\": \"AVSplit\" } ] </property>"
+"  <track producer=\"producer0\"/>"
+"  <track producer=\"tractor0\"/>"
+"  <track producer=\"tractor1\"/>"
+" </tractor>"
+" <chain id=\"chain2\" out=\"%15$s\">"
+"  <property name=\"length\">%2$d</property>"
+"  <property name=\"eof\">pause</property>"
+"  <property name=\"resource\">%5$s</property>"
+"  <property name=\"audio_index\">1</property>"
+"  <property name=\"video_index\">0</property>"
+"  <property name=\"kdenlive:id\">4</property>"
+"  <property name=\"mute_on_pause\">0</property>"
+"  <property name=\"kdenlive:clip_type\">0</property>"
+" </chain>"
+" <playlist id=\"main_bin\">"
+"  <property name=\"kdenlive:docproperties.kdenliveversion\">23.08.5</property>"
+"  <property name=\"kdenlive:docproperties.uuid\">maintractor</property>"
+"  <property name=\"kdenlive:docproperties.version\">1.1</property>"
+"  <property name=\"kdenlive:docproperties.opensequences\">maintractor</property>"
+"  <property name=\"kdenlive:docproperties.activetimeline\">maintractor</property>"
+"  <property name=\"xml_retain\">1</property>"
+"  <entry producer=\"maintractor\" in=\"00:00:00.000\" out=\"00:00:00.000\"/>"
+"  <entry producer=\"chain2\" in=\"00:00:00.000\" out=\"%15$s\"/>"
+" </playlist>"
+" <tractor id=\"tractor2\" in=\"00:00:00.000\" out=\"%14$s\">"
+"  <property name=\"kdenlive:projectTractor\">1</property>"
+"  <track producer=\"maintractor\" in=\"00:00:00.000\" out=\"%14$s\"/>"
+" </tractor>"
 "</mlt>"
 ;
-
-
-


### PR DESCRIPTION
Current kdenlive does not like frame positions as timepoints any more, so we use timestrings instead

Also audio and video tracks are handled seperately now, so we need to create a track for each.