### PR TITLE
build: fix mxml linking aginst version 4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ MXML_LIBS := $(shell pkg-config --libs mxml$(MXML_VERSION))
 DEBUGopts = -g -O0 -fno-inline-functions -DDEBUG
 NDEBUGopts = $(EXTRA_CFLAGS) -O2 -DNDEBUG
 CFLAGS = -Wall -g -Wpedantic -c $(DEBUG) -D_FILE_OFFSET_BITS=64 -DFUSE_USE_VERSION=25 $(MXML_CFLAGS)
-LFLAGS = -Wall -g -Wpedantic -lmxml -lfuse $(DEBUG) $(EXTRA_LFLAGS) $(MXML_LFLAGS)
+LFLAGS = -Wall -g -Wpedantic -lfuse $(DEBUG) $(EXTRA_LFLAGS) $(MXML_LIBS)
 CC = gcc
 DEBUG=$(NDEBUGopts)
 


### PR DESCRIPTION
There were to issues with the previous commit addressing mxml4 support:

* -lmxml is always appended to the link flags, but mxml4 needs -lmxml4.
* MXML_LFLAGS is appended to the link flags, but is empty (actually, MXML_LIBS was meant).

This causes build errors with only mxml4 on the system and includes mxml4 headers, but links against older mxml versions when both are present. The only consistent and successful build is with only old mxml versions installed on the system.

Fixes: https://github.com/a-tze/fuse-ts/issues/20