### PR TITLE
Missing pkg-config build dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Maintainer: Matthias Hunstock <atze@fem.tu-ilmenau.de>
 Section: video
 Priority: optional
 Standards-Version: 3.9.4
-Build-Depends: debhelper (>= 9), libmxml-dev, libfuse-dev
+Build-Depends: debhelper (>= 9), libmxml-dev, libfuse-dev, pkg-config
 
 Package: fuse-ts
 Architecture: any


### PR DESCRIPTION
Due to the switch to mxml4, pkg-config is now a build dependecy